### PR TITLE
Functionality for steady-state PDEs in spherical coordinates

### DIFF
--- a/neurodiffeq/pde_spherical.py
+++ b/neurodiffeq/pde_spherical.py
@@ -1,0 +1,527 @@
+import torch
+import torch.optim as optim
+import torch.nn as nn
+
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.animation as animation
+
+from .networks import FCNN
+from .neurodiffeq import diff
+from copy import deepcopy
+
+
+def _nn_output_spherical_input(net, rs, thetas, phis):
+    points = torch.cat((rs, thetas, phis), 1)
+    return net(points)
+
+
+class NoConditionSpherical:
+    @staticmethod
+    def enforce(net, r, theta, phi):
+        return _nn_output_spherical_input(net, r, theta, phi)
+
+
+class ExampleGenerator3D:
+    """An example generator for generating 3-D training points. NOT TO BE CONFUSED with `ExampleGeneratorSpherical`
+        :param grid: The discretization of the 3 dimensions, if we want to generate points on a :math:`m \\times n \\times k` grid, then `grid` is `(m, n, k)`, defaults to `(10, 10, 10)`.
+        :type grid: tuple[int, int, int], optional
+        :param xyz_min: The lower bound of 3 dimensions, if we only care about :math:`x \\geq x_0`, :math:`y \\geq y_0`, and :math:`z \\geq z_0` then `xyz_min` is `(x_0, y_0, z_0)`, defaults to `(0.0, 0.0, 0.0)`.
+        :type xyz_min: tuple[float, float, float], optional
+        :param xyz_max: The upper bound of 3 dimensions, if we only care about :math:`x \\leq x_1`, :math:`y \\leq y_1`, and :math:`z \\leq z_1` then `xyz_max` is `(x_1, y_1, z_1)`, defaults to `(1.0, 1.0, 1.0)`.
+        :type xyz_max: tuple[float, float, float], optional
+        :param method: The distribution of the 2-D points generated.
+            If set to 'equally-spaced', the points will be fixed to the grid specified.
+            If set to 'equally-spaced-noisy', a normal noise will be added to the previously mentioned set of points, defaults to 'equally-spaced-noisy'.
+        :type method: str, optional
+        :raises ValueError: When provided with an unknown method.
+    """
+
+    def __init__(self, grid=(10, 10, 10), xyz_min=(0.0, 0.0, 0.0), xyz_max=(1.0, 1.0, 1.0),
+                 method='equally-spaced-noisy'):
+        r"""Initializer method
+
+        .. note::
+            A instance method `get_examples` is dynamically created to generate 2-D training points. It will be called by the function `solve2D`.
+        """
+        self.size = grid[0] * grid[1] * grid[2]
+
+        x = torch.linspace(xyz_min[0], xyz_max[0], grid[0], requires_grad=True)
+        y = torch.linspace(xyz_min[1], xyz_max[1], grid[1], requires_grad=True)
+        z = torch.linspace(xyz_min[2], xyz_max[2], grid[2], requires_grad=True)
+        grid_x, grid_y, grid_z = torch.meshgrid(x, y, z)
+        self.grid_x, self.grid_y, self.grid_z = grid_x.flatten(), grid_y.flatten(), grid_z.flatten()
+
+        if method == 'equally-spaced':
+            self.get_examples = lambda: (self.grid_x, self.grid_y, self.grid_z)
+        elif method == 'equally-spaced-noisy':
+            self.noise_xmean = torch.zeros(self.size)
+            self.noise_ymean = torch.zeros(self.size)
+            self.noise_zmean = torch.zeros(self.size)
+            self.noise_xstd = torch.ones(self.size) * ((xyz_max[0] - xyz_min[0]) / grid[0]) / 4.0
+            self.noise_ystd = torch.ones(self.size) * ((xyz_max[1] - xyz_min[1]) / grid[1]) / 4.0
+            self.noise_zstd = torch.ones(self.size) * ((xyz_max[2] - xyz_min[2]) / grid[2]) / 4.0
+            self.get_examples = lambda: (
+                self.grid_x + torch.normal(mean=self.noise_xmean, std=self.noise_xstd),
+                self.grid_y + torch.normal(mean=self.noise_ymean, std=self.noise_ystd),
+                self.grid_z + torch.normal(mean=self.noise_zmean, std=self.noise_zstd),
+            )
+        else:
+            raise ValueError(f'Unknown method: {method}')
+
+
+class ExampleGeneratorSpherical:
+    """An example generator for generating points in spherical coordinates. NOT TO BE CONFUSED with `ExampleGenerator3D`
+    :param size: number of points in 3-D sphere
+    :type size: int
+    :param r_min: radius of the interior boundary
+    :type r_min: float, optional
+    :param r_max: radius of the exterior boundary
+    :type r_max: float, optional
+    :param method: The distribution of the 2-D points generated.
+        If set to 'equally-radius-noisy', radius of the points will be drawn from a uniform distribution :math:`r \sim U[r_{min}, r_{max}]`
+        If set to 'equally-spaced-noisy', squared radius of the points will be drawn from a uniform distribution :math:`r^2 \sim U[r_{min}^2, r_{max}^2]`
+    :type method: str, optional
+    """
+
+    def __init__(self, size, r_min=0., r_max=1., method='equally-spaced-noisy'):
+        if r_min < 0 or r_max < r_min:
+            raise ValueError(f"Illegal range [f{r_min}, {r_max}]")
+
+        if method == 'equally-spaced-noisy':
+            lower = r_min ** 2
+            upper = r_max ** 2
+            rng = upper - lower
+            self.get_r = lambda: torch.sqrt(rng * torch.rand(self.shape) + lower)
+        elif method == "equally-radius-noisy":
+            lower = r_min
+            upper = r_max
+            rng = upper - lower
+            self.get_r = lambda: rng * torch.rand(self.shape) + lower
+        else:
+            raise ValueError(f'Unknown method: {method}')
+
+        self.size = size  # stored for `solve_spherical_system` to access
+        self.shape = (size,)  # used for `self.get_example()`
+
+    def get_examples(self):
+        a = torch.rand(self.shape)
+        b = torch.rand(self.shape)
+        c = torch.rand(self.shape)
+        denom = a + b + c
+        # `x`, `y`, `z` here are just for computation of `theta` and `phi`
+        epsilon = 1e-6
+        x = torch.sqrt(a / denom) + epsilon
+        y = torch.sqrt(b / denom) + epsilon
+        z = torch.sqrt(c / denom) + epsilon
+        # `sign_x`, `sign_y`, `sign_z` are either -1 or +1
+        sign_x = torch.randint(0, 2, self.shape) * 2 - 1
+        sign_y = torch.randint(0, 2, self.shape) * 2 - 1
+        sign_z = torch.randint(0, 2, self.shape) * 2 - 1
+
+        x = x * sign_x
+        y = y * sign_y
+        z = z * sign_z
+
+        theta = torch.acos(z).requires_grad_(True)
+        phi = torch.atan2(y, x).requires_grad_(True)
+        r = self.get_r().requires_grad_(True)
+
+        return r, theta, phi
+
+
+class DirichletBVPSpherical:
+    """Dirichlet boundary condition for the interior and exterior boundary of the sphere, where the interior boundary is not necessarily a point
+        We are solving :math:`u(t)` given :math:`u(r, \\theta, \\phi)\\bigg|_{r = r_0} = f(\\theta, \\phi)` and :math:`u(r, \\theta, \\phi)\\bigg|_{r = r_1} = g(\\theta, \\phi)`
+
+    :param r_0: The radius of the interior boundary. When r_0 = 0, the interior boundary is collapsed to a single point (center of the ball)
+    :type r_0: float
+    :param r_1: The radius of the exterior boundary
+    :type r_1: float
+    :param f: The value of :math:u on the interior boundary. :math:`u(r, \\theta, \\phi)\\bigg|_{r = r_0} = f(\\theta, \\phi)`.
+    :type f: function
+    :param g: The value of :math:u on the exterior boundary. :math:`u(r, \\theta, \\phi)\\bigg|_{r = r_1} = g(\\theta, \\phi)`.
+    :type g: function
+    """
+
+    def __init__(self, r_0, f, r_1, g):
+        """Initializer method
+        """
+        self.r_0, self.r_1 = r_0, r_1
+        self.f, self.g = f, g
+
+    def enforce(self, net, r, theta, phi):
+        r"""Enforce the output of a neural network to satisfy the boundary condition.
+
+        :param net: The neural network that approximates the ODE.
+        :type net: `torch.nn.Module`
+        :param r: The radii of points where the neural network output is evaluated.
+        :type r: `torch.tensor`
+        :param theta: The latitudes of points where the neural network output is evaluated. `theta` ranges [0, pi]
+        :type theta: `torch.tensor`
+        :param phi: The longitudes of points where the neural network output is evaluated. `phi` ranges [0, 2*pi)
+        :type phi: `torch.tensor`
+        :return: The modified output which now satisfies the boundary condition.
+        :rtype: `torch.tensor`
+
+
+        .. note::
+            `enforce` is meant to be called by the function `solve` and `solve_system`.
+        """
+        u = _nn_output_spherical_input(net, r, theta, phi)
+        r_tilde = (r - self.r_0) / (self.r_1 - self.r_0)
+        # noinspection PyTypeChecker
+        return self.f(theta, phi) * (1 - r_tilde) + \
+               self.g(theta, phi) * r_tilde + \
+               (1. - torch.exp((1 - r_tilde) * r_tilde)) * u
+
+
+class SolutionSpherical:
+    """A solution to a PDE (system) in spherical coordinates
+
+    :param nets: The neural networks that approximate the PDE.
+    :type nets: list[`torch.nn.Module`]
+    :param conditions: The conditions of the PDE (system).
+    :type conditions: list[`neurodiffeq.pde_spherical.DirichletBVPSpherical` or `neurodiffeq.pde_spherical.NoCondition`]
+    """
+
+    def __init__(self, nets, conditions):
+        """Initializer method
+        """
+        self.nets = deepcopy(nets)
+        self.conditions = deepcopy(conditions)
+
+    def __call__(self, rs, thetas, phis, as_type='tf'):
+        """Evaluate the solution at certain points.
+
+        :param rs: The radii of points where the neural network output is evaluated.
+        :type rs: `torch.tensor`
+        :param thetas: The latitudes of points where the neural network output is evaluated. `theta` ranges [0, pi]
+        :type thetas: `torch.tensor`
+        :param phis: The longitudes of points where the neural network output is evaluated. `phi` ranges [0, 2*pi)
+        :type phis: `torch.tensor`
+        :param as_type: Whether the returned value is a `torch.tensor` ('tf') or `numpy.array` ('np').
+        :type as_type: str
+        :return: dependent variables are evaluated at given points.
+        :rtype: list[`torch.tensor` or `numpy.array` (when there is more than one dependent variables)
+            `torch.tensor` or `numpy.array` (when there is only one dependent variable)
+        """
+        if not isinstance(rs, torch.Tensor):
+            rs = torch.tensor(rs, dtype=torch.float32)
+        if not isinstance(thetas, torch.Tensor):
+            thetas = torch.tensor(thetas, dtype=torch.float32)
+        if not isinstance(phis, torch.Tensor):
+            phis = torch.tensor(phis, dtype=torch.float32)
+        original_shape = rs.shape
+        rs = rs.reshape(-1, 1)
+        thetas = thetas.reshape(-1, 1)
+        phis = phis.reshape(-1, 1)
+        if as_type not in ('tf', 'np'):
+            raise ValueError("The valid return types are 'tf' and 'np'.")
+
+        vs = [
+            con.enforce(net, rs, thetas, phis).reshape(original_shape)
+            for con, net in zip(self.conditions, self.nets)
+        ]
+        if as_type == 'np':
+            vs = [v.detach().numpy().flatten() for v in vs]
+
+        return vs if len(self.nets) > 1 else vs[0]
+
+
+def solve_spherical(
+        pde, condition, r_min, r_max,
+        net=None, train_generator=None, shuffle=True, valid_generator=None,
+        optimizer=None, criterion=None, batch_size=16, max_epochs=1000,
+        monitor=None, return_internal=False, return_best=False
+):
+    """Train a neural network to solve one PDE with spherical inputs in 3D space
+
+        :param pde: The PDE to solve. If the PDE is :math:`F(u, r,\\theta, \\phi) = 0` where :math:`u` is the dependent variable and :math:`r`, :math:`\\theta` and :math:`\\phi` are the independent variables,
+            then `pde` should be a function that maps :math:`(u, r, \\theta, \\phi)` to :math:`F(u, r,\\theta, \\phi)`
+        :type pde: function
+        :param condition: The initial/boundary condition that :math:`u` should satisfy.
+        :type condition: `neurodiffeq.pde_spherical.DirichletBVPSpherical` or `neurodiffeq.pde_spherical.NoConditionSpherical`
+        :param r_min: The lower bound of radius, if we only care about :math:`r \\geq r_0` , then `r_min` is `r_0`.
+        :type r_min: float
+        :param r_max: The upper bound of radius, if we only care about :math:`r \\leq r_1` , then `r_max` is `r_1`.
+        :type r_max: float
+        :param net: The neural network used to approximate the solution, defaults to None.
+        :type net: `torch.nn.Module`, optional
+        :param train_generator: The example generator to generate 3-D training points, default to None.
+        :type train_generator: `neurodiffeq.pde_spherical.ExampleGeneratorSpherical`, optional
+        :param shuffle: Whether to shuffle the training examples every epoch, defaults to True.
+        :type shuffle: bool, optional
+        :param valid_generator: The example generator to generate 3-D validation points, default to None.
+        :type valid_generator: `neurodiffeq.pde_spherical.ExampleGeneratorSpherical`, optional
+        :param optimizer: The optimization method to use for training, defaults to None.
+        :type optimizer: `torch.optim.Optimizer`, optional
+        :param criterion: The loss function to use for training, defaults to None.
+        :type criterion: `torch.nn.modules.loss._Loss`, optional
+        :param batch_size: The shape of the mini-batch to use, defaults to 16.
+        :type batch_size: int, optional
+        :param max_epochs: The maximum number of epochs to train, defaults to 1000.
+        :type max_epochs: int, optional
+        :param monitor: The monitor to check the status of neural network during training, defaults to None.
+        :type monitor: `neurodiffeq.pde_spherical.MonitorSpherical`, optional
+        :param return_internal: Whether to return the nets, conditions, training generator, validation generator, optimizer and loss function, defaults to False.
+        :type return_internal: bool, optional
+        :param return_best: Whether to return the nets that achieved the lowest validation loss, defaults to False.
+        :type return_best: bool, optional
+        :return: The solution of the PDE. The history of training loss and validation loss.
+            Optionally, the nets, conditions, training generator, validation generator, optimizer and loss function.
+            The solution is a function that has the signature `solution(xs, ys, as_type)`.
+        :rtype: tuple[`neurodiffeq.pde_spherical.SolutionSpherical`, dict]; or tuple[`neurodiffeq.pde_spherical.SolutionSpherical`, dict, dict]
+        """
+
+    pde_sytem = lambda u, r, theta, phi: [pde(u, r, theta, phi)]
+    conditions = [condition]
+    nets = [net] if net is not None else None
+
+    return solve_spherical_system(
+        pde_system=pde_sytem, conditions=conditions, r_min=r_min, r_max=r_max,
+        nets=nets, train_generator=train_generator, shuffle=shuffle, valid_generator=valid_generator,
+        optimizer=optimizer, criterion=criterion, batch_size=batch_size, max_epochs=max_epochs,
+        monitor=monitor, return_internal=return_internal, return_best=return_best,
+    )
+
+
+def solve_spherical_system(
+        pde_system, conditions, r_min, r_max,
+        nets=None, train_generator=None, shuffle=True, valid_generator=None,
+        optimizer=None, criterion=None, batch_size=16,
+        max_epochs=1000,
+        monitor=None, return_internal=False, return_best=False
+):
+    """Train a neural network to solve a PDE system with spherical inputs in 3D space
+
+        :param pde_system: The PDEsystem to solve. If the PDE is :math:`F_i(u_1, u_2, ..., u_n, r,\\theta, \\phi) = 0` where :math:`u_i` is the i-th dependent variable and :math:`r`, :math:`\\theta` and :math:`\\phi` are the independent variables,
+            then `pde_system` should be a function that maps :math:`(u_1, u_2, ..., u_n, r, \\theta, \\phi)` to a list where the i-th entry is :math:`F_i(u_1, u_2, ..., u_n, r, \\theta, \\phi)`.
+        :type pde_system: function
+        :param conditions: The initial/boundary conditions. The ith entry of the conditions is the condition that :math:`u_i` should satisfy.
+        :type conditions: list[`neurodiffeq.pde_spherical.DirichletBVPSpherical` or `neurodiffeq.pde_spherical.NoConditionSpherical`]
+        :param r_min: The lower bound of radius, if we only care about :math:`r \\geq r_0` , then `r_min` is `r_0`.
+        :type r_min: float
+        :param r_max: The upper bound of radius, if we only care about :math:`r \\leq r_1` , then `r_max` is `r_1`.
+        :type r_max: float
+        :param nets: The neural networks used to approximate the solution, defaults to None.
+        :type nets: list[`torch.nn.Module`], optional
+        :param train_generator: The example generator to generate 3-D training points, default to None.
+        :type train_generator: `neurodiffeq.pde_spherical.ExampleGeneratorSpherical`, optional
+        :param shuffle: Whether to shuffle the training examples every epoch, defaults to True.
+        :type shuffle: bool, optional
+        :param valid_generator: The example generator to generate 3-D validation points, default to None.
+        :type valid_generator: `neurodiffeq.pde_spherical.ExampleGeneratorSpherical`, optional
+        :param optimizer: The optimization method to use for training, defaults to None.
+        :type optimizer: `torch.optim.Optimizer`, optional
+        :param criterion: The loss function to use for training, defaults to None.
+        :type criterion: `torch.nn.modules.loss._Loss`, optional
+        :param batch_size: The shape of the mini-batch to use, defaults to 16.
+        :type batch_size: int, optional
+        :param max_epochs: The maximum number of epochs to train, defaults to 1000.
+        :type max_epochs: int, optional
+        :param monitor: The monitor to check the status of neural network during training, defaults to None.
+        :type monitor: `neurodiffeq.pde_spherical.MonitorSpherical`, optional
+        :param return_internal: Whether to return the nets, conditions, training generator, validation generator, optimizer and loss function, defaults to False.
+        :type return_internal: bool, optional
+        :param return_best: Whether to return the nets that achieved the lowest validation loss, defaults to False.
+        :type return_best: bool, optional
+        :return: The solution of the PDE. The history of training loss and validation loss.
+            Optionally, the nets, conditions, training generator, validation generator, optimizer and loss function.
+            The solution is a function that has the signature `solution(xs, ys, as_type)`.
+        :rtype: tuple[`neurodiffeq.pde_spherical.SolutionSpherical`, dict]; or tuple[`neurodiffeq.pde_spherical.SolutionSpherical`, dict, dict]
+        """
+    # default values
+    n_dependent_vars = len(conditions)
+    if not nets:
+        nets = [
+            FCNN(n_input_units=3, n_hidden_units=32, n_hidden_layers=1, actv=nn.Tanh)
+            for _ in range(n_dependent_vars)
+        ]
+    if not train_generator:
+        train_generator = ExampleGeneratorSpherical(512, r_min, r_max, method='equally-spaced-noisy')
+    if not valid_generator:
+        valid_generator = ExampleGeneratorSpherical(512, r_min, r_max, method='equally-spaced-noisy')
+    if not optimizer:
+        all_parameters = []
+        for net in nets:
+            all_parameters += list(net.parameters())
+        optimizer = optim.Adam(all_parameters, lr=0.001)
+    if not criterion:
+        criterion = nn.MSELoss()
+
+    if return_internal:
+        internal = {
+            'nets': nets,
+            'conditions': conditions,
+            'train_generator': train_generator,
+            'valid_generator': valid_generator,
+            'optimizer': optimizer,
+            'criterion': criterion
+        }
+
+    n_examples_train = train_generator.size
+    n_examples_valid = valid_generator.size
+    # R.H.S. for the PDE system
+    train_zeros = torch.zeros(batch_size).reshape((-1, 1))
+    valid_zeros = torch.zeros(n_examples_valid).reshape((-1, 1))
+
+    loss_history = {'train': [], 'valid': []}
+    valid_loss_epoch_min = np.inf
+    solution_min = None
+
+    for epoch in range(max_epochs):
+        train_loss_epoch = 0.0
+
+        train_examples_r, train_examples_theta, train_examples_phi = train_generator.get_examples()
+        train_examples_r = train_examples_r.reshape((-1, 1))
+        train_examples_theta = train_examples_theta.reshape((-1, 1))
+        train_examples_phi = train_examples_phi.reshape((-1, 1))
+        idx = np.random.permutation(n_examples_train) if shuffle else np.arange(n_examples_train)
+        batch_start, batch_end = 0, batch_size
+
+        while batch_start < n_examples_train:
+            if batch_end > n_examples_train:
+                batch_end = n_examples_train
+            batch_idx = idx[batch_start:batch_end]
+            rs = train_examples_r[batch_idx]
+            thetas = train_examples_theta[batch_idx]
+            phis = train_examples_phi[batch_idx]
+
+            # the dependet variables
+            us = [
+                con.enforce(net, rs, thetas, phis)
+                for con, net in zip(conditions, nets)
+            ]
+
+            Fs = pde_system(*us, rs, thetas, phis)
+            loss = 0.0
+            for F in Fs:
+                loss += criterion(F, train_zeros)  # type: torch.Tensor
+            train_loss_epoch += loss.item() * (batch_end - batch_start) / n_examples_train
+
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+            batch_start += batch_size
+            batch_end += batch_size
+
+        loss_history['train'].append(train_loss_epoch)
+
+        # calculate the validation loss
+        valid_examples_rs, valid_examples_thetas, valid_examples_phis = valid_generator.get_examples()
+        rs = valid_examples_rs.reshape(-1, 1)
+        thetas = valid_examples_thetas.reshape(-1, 1)
+        phis = valid_examples_phis.reshape(-1, 1)
+        us = [
+            con.enforce(net, rs, thetas, phis)
+            for con, net in zip(conditions, nets)
+        ]
+        Fs = pde_system(*us, rs, thetas, phis)
+        valid_loss_epoch = 0.0
+        for F in Fs:
+            valid_loss_epoch += criterion(F, valid_zeros)
+        valid_loss_epoch = valid_loss_epoch.item()
+
+        loss_history['valid'].append(valid_loss_epoch)
+
+        if monitor and epoch % monitor.check_every == 0:
+            monitor.check(nets, conditions, loss_history)
+
+        if return_best and valid_loss_epoch < valid_loss_epoch_min:
+            valid_loss_epoch_min = valid_loss_epoch
+            solution_min = SolutionSpherical(nets, conditions)
+
+    if return_best:
+        solution = solution_min
+    else:
+        solution = SolutionSpherical(nets, conditions)
+
+    if return_internal:
+        # noinspection PyUnboundLocalVariable
+        return solution, loss_history, internal
+    else:
+        return solution, loss_history
+
+
+class MonitorSpherical:
+    """A monitor for checking the status of the neural network during training.
+
+    :param r_min: The lower bound of radius, i.e., radius of interior boundary
+    :type r_min: float
+    :param r_max: The upper bound of radius, i.e., radius of exterior boundary
+    :type r_max: float
+    :param check_every: The frequency of checking the neural network represented by the number of epochs between two checks, defaults to 100.
+    :type check_every: int, optional
+    """
+
+    def __init__(self, r_min, r_max, check_every=100):
+        """Initializer method
+        """
+        self.check_every = check_every
+        self.fig = None
+        self.axs = []  # subplots
+        self.cbs = []  # color bars
+        # input for neural network
+        gen = ExampleGeneratorSpherical(256, r_min=r_min, r_max=r_max, method='equally-spaced-noisy')
+        rs_ann, thetas_ann, phis_ann = gen.get_examples()
+        self.rs_ann = rs_ann.reshape(-1, 1)
+        self.thetas_ann = thetas_ann.reshape(-1, 1)
+        self.phis_ann = phis_ann.reshape(-1, 1)
+        # self.xy_ann = torch.cat((self.xs_ann, self.ys_ann), 1)
+
+    def check(self, nets, conditions, loss_history):
+        r"""Draw 2 plots: One shows the shape of the current solution (with heat map). The other shows the history training loss and validation loss.
+
+        :param nets: The neural networks that approximates the PDE.
+        :type nets: list [`torch.nn.Module`]
+        :param conditions: The initial/boundary condition of the PDE.
+        :type conditions: list [`neurodiffeq.pde_spherical.DirichletBVPSpherical` or `neurodiffeq.pde_spherical.NoConditionSpherical`]
+        :param loss_history: The history of training loss and validation loss. The 'train' entry is a list of training loss and 'valid' entry is a list of validation loss.
+        :type loss_history: dict['train': list[float], 'valid': list[float]]
+
+        .. note::
+            `check` is meant to be called by the function `solve2D`.
+        """
+
+        if not self.fig:
+            # initialize the figure and axes here so that the Monitor knows the number of dependent variables and
+            # shape of the figure, number of the subplots, etc.
+            n_axs = len(nets) + 1  # one for each dependent variable, another one for training and validation loss
+            n_row, n_col = (n_axs + 1) // 2, 2
+            self.fig = plt.figure(figsize=(20, 8 * n_row))
+            for i in range(n_axs):
+                self.axs.append(self.fig.add_subplot(n_row, n_col, i + 1))
+            for i in range(len(nets)):
+                self.cbs.append(None)
+
+        us = [
+            con.enforce(net, self.rs_ann, self.thetas_ann, self.phis_ann)
+            for con, net in zip(conditions, nets)
+        ]
+
+        for i, ax_u in enumerate(zip(self.axs[:-1], us)):
+            ax, u = ax_u
+            ax.clear()
+            # TODO visualize 3D ball
+            # u_as_mat = u.detach().numpy().reshape((32, 32))
+            # cax = ax.matshow(u_as_mat, cmap='hot', interpolation='nearest')
+            # if self.cbs[i]:
+            #     self.cbs[i].remove()
+            # self.cbs[i] = self.fig.colorbar(cax, ax=ax)
+            ax.set_title(f'u[{i}](r, theta, phi)')
+
+        self.axs[-1].clear()
+        self.axs[-1].plot(loss_history['train'], label='training loss')
+        self.axs[-1].plot(loss_history['valid'], label='validation loss')
+        self.axs[-1].set_title('loss during training')
+        self.axs[-1].set_ylabel('loss')
+        self.axs[-1].set_xlabel('epochs')
+        self.axs[-1].set_yscale('log')
+        self.axs[-1].legend()
+
+        self.fig.canvas.draw()
+        # for command-line, interactive plots, not pausing can lead to graphs not being displayed at all
+        # see https://stackoverflow.com/questions/19105388/python-2-7-mac-osx-interactive-plotting-with-matplotlib-not-working
+        plt.pause(0.05)

--- a/tests/test_pde_spherical.py
+++ b/tests/test_pde_spherical.py
@@ -155,3 +155,43 @@ def test_solve_spherical_system():
     assert np.isclose(vs, np.ones(512), atol=0.005).all(), f"Solution v is not straight 1s: {vs}"
 
     print("solve_spherical_system tests passed")
+
+
+def test_electric_potential_uniformly_charged_ball():
+    """
+    electric potential on uniformly charged solid sphere
+    refer to http://www.phys.uri.edu/~gerhard/PHY204/tsl94.pdf
+    """
+    # free charge volume density
+    rho = 1.
+    # medium permittivity
+    epsilon = 1.
+    # Coulomb constant
+    k = 1. / (4 * np.pi * epsilon)
+    # radius of the ball
+    R = 1.
+    # total electric charge on solid sphere
+    Q = (4 / 3) * np.pi * (R ** 3) * rho
+    # electric potential at sphere center
+    v_0 = 1.5 * k * Q / R
+    # electric potential on sphere boundary
+    v_R = k * Q / R
+    # analytic solution of electric potential
+    analytic_solution = lambda r, th, ph: k * Q / (2 * R) * (3 - (r / R) ** 2)
+
+    pde = lambda u, r, theta, phi: laplacian_spherical(u, r, theta, phi) + rho / epsilon
+    condition = DirichletBVPSpherical(r_0=0., f=lambda th, ph: v_0, r_1=R, g=lambda th, ph: v_R)
+    monitor = MonitorSpherical(0.0, R, check_every=50)
+
+    solution, loss_history, analytic_mse = solve_spherical(pde, condition, 0., R, max_epochs=100, return_best=True,
+                                                           analytic_solution=analytic_solution, monitor=monitor)
+    generator = ExampleGeneratorSpherical(512)
+    rs, thetas, phis = generator.get_examples()
+    us = solution(rs, thetas, phis, as_type="np")
+    vs = analytic_solution(rs, thetas, phis).detach().numpy()
+    abs_diff = abs(us - vs)
+
+    assert np.isclose(us, vs, atol=0.005).all(), \
+        f"Solution doesn't match analytic expectation {us} != {vs}, abs_diff={abs_diff}"
+
+    print("electric-potential-on-uniformly-charged-solid-sphere passed")

--- a/tests/test_pde_spherical.py
+++ b/tests/test_pde_spherical.py
@@ -1,0 +1,128 @@
+import torch
+import torch.nn as nn
+import numpy as np
+import unittest
+from pytest import raises
+from neurodiffeq import diff
+from neurodiffeq.pde_spherical import ExampleGeneratorSpherical, ExampleGenerator3D
+from neurodiffeq.pde_spherical import NoConditionSpherical, DirichletBVPSpherical
+from neurodiffeq.pde_spherical import solve_spherical, solve_spherical_system
+from neurodiffeq.pde_spherical import SolutionSpherical
+from neurodiffeq.pde_spherical import MonitorSpherical
+
+
+def laplacian_spherical(u, r, theta, phi):
+    """a helper function that computes the Laplacian in spherical coordinates
+    """
+    r_component = diff(u * r, r, order=2) / r
+    theta_component = diff(torch.sin(theta) * diff(u, theta), theta) / (r ** 2 * torch.sin(theta))
+    phi_component = diff(u, phi, order=2) / (r ** 2 * torch.sin(theta) ** 2)
+    return r_component + theta_component + phi_component
+
+
+def test_dirichlet_bvp_spherical():
+    # B.C. for the interior boundary (r_min)
+    interior = nn.Linear(in_features=2, out_features=1, bias=True)
+    f = lambda theta, phi: interior(torch.cat([theta, phi], dim=1))
+
+    # B.C. for the exterior boundary (r_max)
+    exterior = nn.Linear(in_features=2, out_features=1, bias=True)
+    g = lambda theta, phi: exterior(torch.cat([theta, phi], dim=1))
+
+    bvp = DirichletBVPSpherical(r_0=0., f=f, r_1=1.0, g=g)
+
+    net = nn.Linear(in_features=3, out_features=1, bias=True)
+    theta = torch.rand(10, 1) * np.pi
+    phi = torch.rand(10, 1) * 2 * np.pi
+
+    r = torch.zeros_like(theta)
+    v0 = f(theta, phi).detach().numpy()
+    u0 = bvp.enforce(net, r, theta, phi).detach().numpy()
+    assert np.isclose(v0, u0, atol=1.e-5).all(), f"Unmatched boundary {v0} != {u0}"
+
+    r = torch.ones_like(theta)
+    v1 = g(theta, phi).detach().numpy()
+    u1 = bvp.enforce(net, r, theta, phi).detach().numpy()
+    assert np.isclose(v0, u0, atol=1.e-5).all(), f"Unmatched boundary {v1} != {u1}"
+
+    print("DirichletBVPSpherical test passed")
+
+
+def test_train_generator_spherical():
+    pde = laplacian_spherical
+    condition = NoConditionSpherical()
+    train_generator = ExampleGeneratorSpherical(size=64, r_min=0., r_max=1., method='equally-spaced-noisy')
+    valid_generator = ExampleGeneratorSpherical(size=64, r_min=1., r_max=1., method='equally-radius-noisy')
+    solve_spherical(pde, condition, 0.0, 1.0,
+                    train_generator=train_generator,
+                    valid_generator=valid_generator,
+                    max_epochs=5)
+    with raises(ValueError):
+        _ = ExampleGeneratorSpherical(64, method='bad_generator')
+
+    with raises(ValueError):
+        _ = ExampleGeneratorSpherical(64, r_min=-1.0)
+
+    with raises(ValueError):
+        _ = ExampleGeneratorSpherical(64, r_min=1.0, r_max=0.0)
+
+    print("GeneratorSpherical tests passed")
+
+
+def test_solve_spherical():
+    pde = laplacian_spherical
+    generator = ExampleGeneratorSpherical(512)
+
+    # 0-boundary condition; solution should be u(r, theta, phi) = 0 identically
+    f = lambda th, ph: 0.
+    g = lambda th, ph: 0.
+    condition = DirichletBVPSpherical(r_0=0., f=f, r_1=1., g=g)
+    solution, loss_history = solve_spherical(pde, condition, 0.0, 1.0, max_epochs=500, return_best=True)
+    rs, thetas, phis = generator.get_examples()
+    us = solution(rs, thetas, phis, as_type='np')
+    assert np.isclose(us, np.zeros_like(us), atol=0.005).all(), f"Solution is not straight 0s: {us}"
+
+    # 1-boundary condition; solution should be u(r, theta, phi) = 1 identically
+    f = lambda th, ph: 1.
+    g = lambda th, ph: 1.
+    condition = DirichletBVPSpherical(r_0=0., f=f, r_1=1., g=g)
+    solution, loss_history = solve_spherical(pde, condition, 0.0, 1.0, max_epochs=500, return_best=True)
+    rs, thetas, phis = generator.get_examples()
+    us = solution(rs, thetas, phis, as_type='np')
+    assert np.isclose(us, np.ones_like(us), atol=0.005).all(), f"Solution is not straight 1s: {us}"
+
+    print("solve_spherical tests passed")
+
+
+def test_monitor_spherical():
+    pde = laplacian_spherical
+
+    f = lambda th, ph: 0.
+    g = lambda th, ph: 0.
+    condition = DirichletBVPSpherical(r_0=0., f=f, r_1=1., g=g)
+    monitor = MonitorSpherical(0.0, 1.0, check_every=1)
+    solve_spherical(pde, condition, 0.0, 1.0, max_epochs=50, monitor=monitor)
+
+
+def test_solve_spherical_system():
+    # a PDE system that can be decoupled into 2 Laplacian equations :math:`\\nabla^2 u = 0` and :math:`\\nabla^2 v = 0`
+    pde_system = lambda u, v, r, theta, phi: [
+        laplacian_spherical(u, r, theta, phi) + laplacian_spherical(v, r, theta, phi),
+        laplacian_spherical(u, r, theta, phi) - laplacian_spherical(v, r, theta, phi),
+    ]
+
+    # constant boundary conditions for u and v; solution should be u = 0 identically and v = 1 identically
+    conditions = [
+        DirichletBVPSpherical(r_0=0., f=lambda phi, theta: 0., r_1=1., g=lambda phi, theta: 0.),
+        DirichletBVPSpherical(r_0=0., f=lambda phi, theta: 1., r_1=1., g=lambda phi, theta: 1.),
+    ]
+
+    solution, loss_history = solve_spherical_system(pde_system, conditions, 0.0, 1.0, max_epochs=500, return_best=True)
+    generator = ExampleGeneratorSpherical(512, r_min=0., r_max=1.)
+    rs, thetas, phis = generator.get_examples()
+    us, vs = solution(rs, thetas, phis, as_type='np')
+
+    assert np.isclose(us, np.zeros(512), atol=0.005).all(), f"Solution u is not straight 0s: {us}"
+    assert np.isclose(vs, np.ones(512), atol=0.005).all(), f"Solution v is not straight 1s: {vs}"
+
+    print("solve_spherical_system tests passed")


### PR DESCRIPTION
## Implemented functionalities include:
- [x] `ExampleGeneratorSpherical`
- [x] `MonitorSpherical` (loss & MSE against ground analytic solution)
- [x] `solve_spherical_system`
- [x] `solve_spherical`
- [x] `SolutionSpherical`
- [x] `NoConditionSpherical`
- [x] `DirichletBVPSpherical` (only B.C. for `r`, not `theta` or `phi`)
- [x] `InfDirichletBVPSpherical` (BC for `r` at infinity ∞ )

## Tests include:
- [x] `ExampleGeneratorSpherical`
- [x] `MonitorSpherical`
- [x] `solve_spherical_system` (Linearly coupled *Laplacian equations* with constant B.C.) 
- [x] `solve_spherical` (*Laplacian equation* with constant B.C.) 
- [x] Poisson Equation for electric potential inside a uniformly charged solid sphere (see [problem settings](https://en.wikipedia.org/wiki/Poisson%27s_equation#Electrostatics) and [analytic solutions](http://www.phys.uri.edu/~gerhard/PHY204/tsl94.pdf))
- [x] `DirichletBVPSpherical`
- [x] `InfDirichletBVPSpherical`

Additionally, this commit fixes an issue that causes `neurodiffeq.pde_sphetical.MonitorSpherical` to not show up when a script is run from the command line instead of Jupyter notebooks. If you think the fix is useful, please consider updating `neurodiffeq.ode.Monitor` and `neurodiffeq.pde.Monitor2D` as well.
A reference to the fix can be found [here](https://stackoverflow.com/questions/19105388/python-2-7-mac-osx-interactive-plotting-with-matplotlib-not-working)