### PR TITLE
Get things working with spherical harmonics

### DIFF
--- a/neurodiffeq/networks.py
+++ b/neurodiffeq/networks.py
@@ -71,9 +71,11 @@ class SphericalHarmonicsNN(nn.Module):
     def forward(self, inp: torch.Tensor):
         if len(inp.shape) != 2 or inp.shape[1] != 3:
             raise ValueError(f'Illegal input shape {inp.shape}, must be (N, 3)')
-        r = torch.stack((inp[:, 0],), dim=1)
-        theta = inp[:, 1]
-        phi = inp[:, 2]
+        # use one-element slice; this keeps the second dimension unreduced
+        # see https://discuss.pytorch.org/t/solved-simple-question-about-keep-dim-when-slicing-the-tensor/9280
+        r = inp[:, 0:1]
+        theta = inp[:, 1:2]
+        phi = inp[:, 2:3]
         coefficients = self.r_net(r)
         harmonics = self.harmonics_fn(theta, phi)
         return torch.sum(coefficients * harmonics, dim=1, keepdim=True)

--- a/neurodiffeq/neurodiffeq.py
+++ b/neurodiffeq/neurodiffeq.py
@@ -17,5 +17,6 @@ def diff(x, t, order=1):
     ones = torch.ones_like(x)
     der, = autograd.grad(x, t, create_graph=True, grad_outputs=ones)
     for i in range(1, order):
+        ones = torch.ones_like(der)
         der, = autograd.grad(der, t, create_graph=True, grad_outputs=ones)
     return der


### PR DESCRIPTION
Now we can train a network that output the spherical harmonics _coefficients_ instead of the actual _scalar function_ defined on a 3-ball. 

Originally, the computation of spherical laplacian involves the term 1/sin(θ), which results in singularity around north/south polar regions. This can cause a problem when solving complicated equations.

With spherical harmonics, the computation of spherical laplacians is reduced to mulitplication by constants _l(l+1)_, thereby eliminating polar singularities.  This functionality is implemented in `neurodiffeq.spherical_harmonics.HarmonicsLaplacian`. Another advantage of the spherical harmonics is that spherical harmonics naturally satisfy the periodic boundary conditions.

## Differences with Our Previous Implementation
### Network
Previously, we use networks that take in 3 inputs _(r, θ, ϕ)_ and return 1 output _u_. 

Now we will use a network that takes in 1 input _r_ and returns _(L+1)^2_ many outputs _**R**_ = _(R1, R2, ...)_, where _L_ is the highest degree of spherical harmonics. Each _Ri_ is a function of _r_ and acts as the coefficient for a corresponding spherical harmonic component _Yi_. Because there are _(L+1)^2_ many spherical harmonic components with a degree <= _L_, there are _(L+1)^2_ many outputs accordingly. If we want to compute _u_ using the output ***R***, we can use the equation _u(r, θ, ϕ) = Σ Ri(r)*Yi(θ,ϕ)_


> Note that for simplicity I use the subscript _i_ here; while in reality, we have 2 sub/superscripts _l_ and _m_.


### Boundary Conditions
New classes for different types of boundary conditions are used. Although they resemble very much previously implemented classes, they don't have the same base class. Unifying their base class is one of the possible future tasks.
Since the output of the network is no longer a scalar _u_, but rather a vector _**R**_, the boundary conditions are also specified in terms of _**R**(r0) = **R0**_

### Monitor and Solution class
New classes for Monitor and Solution are used. They are inherited from the original `MonitorSpherical` and `SolutionSpherical`. Note that they do **NOT** plot/return the _**R**_ vector. Instead, they still plot the scalar function *u*.

### Laplacian
Previously, we compute _Δu_ by defining a differential operator,
![image](https://user-images.githubusercontent.com/22414322/75990296-ac7a0180-5f2f-11ea-8630-a2999600db5d.png)
 which in Python is a lambda function that takes in _u_, _r_, _θ_, _ϕ_ as its input. This method is susceptible to polar singularity caused by the _1/sin(θ)_ term.

Now we only need to instantiate the `neurodiffeq.spherical_harmonics.HarmonicsLaplacian` by specifying the highest degree of spherical harmonics we'll need. Then we can compute the laplacian using the equation
![image](https://user-images.githubusercontent.com/22414322/75989294-f95cd880-5f2d-11ea-8763-be67f61431c7.png),
which is way easier to compute and doesn't have singularities.

### Other Differential Operators
If we need to use another differential operator (`my_diff`) instead of the Laplacian, we need to manually do the following things:
```python
harmonics_fn = RealSphericalHarmonics(max_degree=4)
# get the spherical components, which are functions of theta and phi
Y = harmonics_fn(theta, phi)
# get the corresponding coefficients, which are functions of r
R = network(r)
# get the target function, which is a function of r, theta, and phi
u = torch.sum(R*Y, dim=1, keepdim=True)
# apply the differential operator on u
result = my_diff(u, r, theta, phi)
```
(This is in contrast with the laplacian, where we only need `R` instead of `Y` and `u`)